### PR TITLE
Support lazy preloading of instance-dependent associations for Rails 7 and above

### DIFF
--- a/lib/ar_lazy_preload/contexts/base_context.rb
+++ b/lib/ar_lazy_preload/contexts/base_context.rb
@@ -92,7 +92,7 @@ module ArLazyPreload
 
       def preloadable_reflection?(klass, reflection)
         scope = reflection.scope
-        preloadable_scope = scope&.arity&.zero?
+        preloadable_scope = scope&.arity&.zero? || ::ActiveRecord::VERSION::MAJOR >= 7
         through_reflection =
           reflection.options[:through] && klass.reflect_on_association(reflection.options[:through])
         preloadable_through_reflection =

--- a/spec/ar_lazy_preload/ar_lazy_preload_spec.rb
+++ b/spec/ar_lazy_preload/ar_lazy_preload_spec.rb
@@ -79,16 +79,33 @@ describe ArLazyPreload do
       end
 
       context "when the scope takes an argument and is instance-dependant" do
-        subject { Post.lazy_preload(:comments_published_since) }
+        subject { User.lazy_preload(posts: :comments_mentioning_user).first }
 
-        it "doesn't load lazy_preloaded associations" do
-          expected_calls = subject.count + 1
-
-          expect do
-            subject.map do |post|
-              post.comments_published_after_last_update.map(&:id)
-            end
-          end.to make_database_queries(count: expected_calls)
+        if ::ActiveRecord::VERSION::MAJOR >= 7
+          # SELECT "users".* FROM "users" ORDER BY "users"."id" ASC LIMIT ?
+          # SELECT "posts".* FROM "posts" WHERE "posts"."user_id" = ?
+          # SELECT "comments".* FROM "comments" WHERE (comments.body LIKE NULL) AND "comments"."post_id" IN (...)
+          it "loads lazy_preloaded associations" do
+            expect do
+              subject.posts.map do |post|
+                post.comments_mentioning_user.map(&:id)
+              end
+            end.to make_database_queries(count: 3)
+          end
+        else
+          # SELECT "users".* FROM "users" ORDER BY "users"."id" ASC LIMIT ?
+          # SELECT "posts".* FROM "posts" WHERE "posts"."user_id" = ?
+          # SELECT "comments".* FROM "comments" WHERE "comments"."post_id" = ? AND (comments.body LIKE NULL)
+          # SELECT "comments".* FROM "comments" WHERE "comments"."post_id" = ? AND (comments.body LIKE NULL)
+          # SELECT "comments".* FROM "comments" WHERE "comments"."post_id" = ? AND (comments.body LIKE NULL)
+          # SELECT "comments".* FROM "comments" WHERE "comments"."post_id" = ? AND (comments.body LIKE NULL)
+          it "doesn't load lazy_preloaded associations" do
+            expect do
+              subject.posts.map do |post|
+                post.comments_mentioning_user.map(&:id)
+              end
+            end.to make_database_queries(count: 6)
+          end
         end
       end
     end

--- a/spec/helpers/models.rb
+++ b/spec/helpers/models.rb
@@ -21,9 +21,7 @@ class Post < ActiveRecord::Base
   has_many :comments
   has_many :comments_with_preloaded_users, -> { includes(:user) }, class_name: "Comment"
   has_many :comment_threads, -> { threads }, class_name: "Comment"
-  has_many :comments_published_after_last_update, lambda { |post|
-    where("comments.created_at >= ?", post.updated_at)
-  }, class_name: "Comment"
+  has_many :comments_mentioning_user, ->(post) { where("comments.body LIKE ?", post.user.name) }, class_name: "Comment"
   has_many :votes, as: :voteable
 end
 

--- a/spec/helpers/schema.rb
+++ b/spec/helpers/schema.rb
@@ -4,6 +4,8 @@ ActiveRecord::Schema.define do
   self.verbose = false
 
   create_table :users, force: true do |t|
+    t.string :name
+
     t.timestamps null: false
   end
 
@@ -25,6 +27,7 @@ ActiveRecord::Schema.define do
     t.references :post
     t.references :user
     t.integer :parent_comment_id
+    t.text :body
 
     t.timestamps null: false
   end


### PR DESCRIPTION
Rails 7 introduced support for preloading instance-dependent associations via the following pull request:

- https://github.com/rails/rails/pull/42553

This commit adds support for lazy preloading of instance-dependent associations when using Rails 7 or above.